### PR TITLE
feat: add block support to create_hypertable. close #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ class CreateEvent < ActiveRecord::Migration[7.0]
 end
 ```
 
+Create a hypertable without a PostgreSQL table by doing:
+
+```ruby
+class CreatePayloadHypertable < ActiveRecord::Migration[7.0]
+  def change
+    create_hypertable :payloads, :created_at, chunk_time_interval: '5 days' do |t|
+      t.string :ip, null: false
+
+      t.timestamps
+    end
+  end
+end
+```
+
 ## Supported Ruby/Rails versions
 
 Supported Ruby/Rails versions are listed in [`.github/workflows/ci.yaml`](https://github.com/crunchloop/timescaledb-rails/blob/main/.github/workflows/ci.yaml)

--- a/lib/timescaledb/rails/extensions/active_record/schema_dumper.rb
+++ b/lib/timescaledb/rails/extensions/active_record/schema_dumper.rb
@@ -27,17 +27,24 @@ module Timescaledb
 
         def hypertable_options(hypertable)
           options = {
-            chunk_time_interval: hypertable.chunk_time_interval.inspect
+            chunk_time_interval: hypertable.chunk_time_interval
           }
 
           result = options.each_with_object([]) do |(key, value), memo|
-            value = value.inspect unless value.is_a?(String)
-
-            memo << "#{key}: #{value}"
+            memo << "#{key}: #{format_hypertable_option_value(value)}"
             memo
           end
 
           result.join(', ')
+        end
+
+        def format_hypertable_option_value(value)
+          case value
+          when String then value.inspect
+          when ActiveSupport::Duration then value.inspect.inspect
+          else
+            value
+          end
         end
 
         def timescale_enabled?

--- a/lib/timescaledb/rails/extensions/active_record/schema_statements.rb
+++ b/lib/timescaledb/rails/extensions/active_record/schema_statements.rb
@@ -11,8 +11,16 @@ module Timescaledb
         #
         #   create_hypertable('readings', 'created_at', chunk_time_interval: '7 days')
         #
-        def create_hypertable(table_name, time_column_name = 'created_at', **options)
-          options_as_sql = hypertable_options_to_sql(options.symbolize_keys)
+        def create_hypertable(table_name, time_column_name, **options, &block)
+          options = options.symbolize_keys
+          options_as_sql = hypertable_options_to_sql(options)
+
+          if block
+            primary_key = options[:primary_key]
+            force = options[:force]
+
+            create_table(table_name, id: false, primary_key: primary_key, force: force, **options, &block)
+          end
 
           execute "SELECT create_hypertable('#{table_name}', '#{time_column_name}', #{options_as_sql})"
         end

--- a/spec/dummy/db/migrate/3_create_payload_hypertable.rb
+++ b/spec/dummy/db/migrate/3_create_payload_hypertable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreatePayloadHypertable < ActiveRecord::Migration[Rails.version[0..2]]
+  def change
+    create_hypertable :payloads, :created_at, chunk_time_interval: '5 days' do |t|
+      t.string :ip, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2) do
+ActiveRecord::Schema[7.0].define(version: 3) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "timescaledb"
@@ -29,5 +29,14 @@ ActiveRecord::Schema[7.0].define(version: 2) do
   end
 
   create_hypertable "events", "created_at", chunk_time_interval: "2 days"
+
+  create_table "payloads", id: false, force: :cascade do |t|
+    t.string "ip", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "payloads_created_at_idx", order: :desc
+  end
+
+  create_hypertable "payloads", "created_at", chunk_time_interval: "5 days"
 
 end


### PR DESCRIPTION
* Both, creating a PostgreSQL table and converting the table to a hypertable can be done via `create_hypertable` migration API.