### PR TITLE
feat: exclude `_timescaledb_internal` tables from structure.sql.

### DIFF
--- a/gemfiles/6.0.gemfile.lock
+++ b/gemfiles/6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    timescaledb-rails (0.0.1)
+    timescaledb-rails (0.1.1)
       rails (>= 6.0)
 
 GEM

--- a/gemfiles/7.0.gemfile.lock
+++ b/gemfiles/7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    timescaledb-rails (0.0.1)
+    timescaledb-rails (0.1.1)
       rails (>= 6.0)
 
 GEM

--- a/lib/timescaledb/rails/extensions/active_record/database_tasks.rb
+++ b/lib/timescaledb/rails/extensions/active_record/database_tasks.rb
@@ -1,75 +1,30 @@
 # frozen_string_literal: true
 
-require 'active_record/tasks/postgresql_database_tasks'
-require 'timescaledb/rails/orderby_compression'
-
 module Timescaledb
   module Rails
     module ActiveRecord
       # :nodoc:
       module DatabaseTasks
-        def structure_dump(filename, extra_flags)
-          super
+        # @override
+        def structure_dump_flags_for(adapter)
+          return (flags = super) if adapter != 'postgresql'
 
-          return unless timescale_enabled?
-
-          File.open(filename, 'a') do |file|
-            Timescaledb::Rails::Hypertable.all.each do |hypertable|
-              drop_ts_insert_trigger_statment(hypertable, file)
-              create_hypertable_statement(hypertable, file)
-              add_hypertable_compression_statement(hypertable, file)
-            end
+          if flags.nil?
+            timescaledb_structure_dump_default_flags
+          elsif flags.is_a?(Array)
+            flags << timescaledb_structure_dump_default_flags
+          elsif flags.is_a?(String)
+            "#{flags} #{timescaledb_structure_dump_default_flags}"
+          else
+            flags
           end
         end
 
-        def drop_ts_insert_trigger_statment(hypertable, file)
-          file << "---\n"
-          file << "--- Drop ts_insert_blocker previously created by pg_dump to avoid pg errors, create_hypertable will re-create it again.\n" # rubocop:disable Layout/LineLength
-          file << "---\n\n"
-          file << "DROP TRIGGER IF EXISTS ts_insert_blocker ON #{hypertable.hypertable_name};\n"
-        end
-
-        def create_hypertable_statement(hypertable, file)
-          options = hypertable_options(hypertable)
-
-          file << "SELECT create_hypertable('#{hypertable.hypertable_name}', '#{hypertable.time_column_name}', #{options});\n\n" # rubocop:disable Layout/LineLength
-        end
-
-        def add_hypertable_compression_statement(hypertable, file)
-          return unless hypertable.compression?
-
-          options = hypertable_compression_options(hypertable)
-
-          file << "ALTER TABLE #{hypertable.hypertable_name} SET (#{options});\n\n"
-          file << "SELECT add_compression_policy('#{hypertable.hypertable_name}', INTERVAL '#{hypertable.compression_policy_interval}');\n\n" # rubocop:disable Layout/LineLength
-        end
-
-        def hypertable_options(hypertable)
-          sql_statements = ["if_not_exists => 'TRUE'"]
-          sql_statements << "chunk_time_interval => INTERVAL '#{hypertable.chunk_time_interval.inspect}'"
-
-          sql_statements.compact.join(', ')
-        end
-
-        def hypertable_compression_options(hypertable)
-          segmentby_setting = hypertable.compression_settings.segmentby_setting.first
-          orderby_setting = hypertable.compression_settings.orderby_setting.first
-
-          sql_statements = ['timescaledb.compress']
-          sql_statements << "timescaledb.compress_segmentby = '#{segmentby_setting.attname}'" if segmentby_setting
-
-          if orderby_setting
-            orderby = Timescaledb::Rails::OrderbyCompression.new(orderby_setting.attname,
-                                                                 orderby_setting.orderby_asc).to_s
-
-            sql_statements << "timescaledb.compress_orderby = '#{orderby}'"
-          end
-
-          sql_statements.join(', ')
-        end
-
-        def timescale_enabled?
-          Timescaledb::Rails::Hypertable.table_exists?
+        # Returns `pg_dump` flag to exclude `_timescaledb_internal` schema tables.
+        #
+        # @return [String]
+        def timescaledb_structure_dump_default_flags
+          '--exclude-schema=_timescaledb_internal'
         end
       end
     end

--- a/lib/timescaledb/rails/extensions/active_record/postgresql_database_tasks.rb
+++ b/lib/timescaledb/rails/extensions/active_record/postgresql_database_tasks.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'active_record/tasks/postgresql_database_tasks'
+require 'timescaledb/rails/orderby_compression'
+
+module Timescaledb
+  module Rails
+    module ActiveRecord
+      # :nodoc:
+      module PostgreSQLDatabaseTasks
+        # @override
+        def structure_dump(filename, extra_flags)
+          super
+
+          return unless timescale_enabled?
+
+          File.open(filename, 'a') do |file|
+            Timescaledb::Rails::Hypertable.all.each do |hypertable|
+              drop_ts_insert_trigger_statment(hypertable, file)
+              create_hypertable_statement(hypertable, file)
+              add_hypertable_compression_statement(hypertable, file)
+            end
+          end
+        end
+
+        def drop_ts_insert_trigger_statment(hypertable, file)
+          file << "---\n"
+          file << "--- Drop ts_insert_blocker previously created by pg_dump to avoid pg errors, create_hypertable will re-create it again.\n" # rubocop:disable Layout/LineLength
+          file << "---\n\n"
+          file << "DROP TRIGGER IF EXISTS ts_insert_blocker ON #{hypertable.hypertable_name};\n"
+        end
+
+        def create_hypertable_statement(hypertable, file)
+          options = hypertable_options(hypertable)
+
+          file << "SELECT create_hypertable('#{hypertable.hypertable_name}', '#{hypertable.time_column_name}', #{options});\n\n" # rubocop:disable Layout/LineLength
+        end
+
+        def add_hypertable_compression_statement(hypertable, file)
+          return unless hypertable.compression?
+
+          options = hypertable_compression_options(hypertable)
+
+          file << "ALTER TABLE #{hypertable.hypertable_name} SET (#{options});\n\n"
+          file << "SELECT add_compression_policy('#{hypertable.hypertable_name}', INTERVAL '#{hypertable.compression_policy_interval}');\n\n" # rubocop:disable Layout/LineLength
+        end
+
+        def hypertable_options(hypertable)
+          sql_statements = ["if_not_exists => 'TRUE'"]
+          sql_statements << "chunk_time_interval => INTERVAL '#{hypertable.chunk_time_interval.inspect}'"
+
+          sql_statements.compact.join(', ')
+        end
+
+        def hypertable_compression_options(hypertable)
+          segmentby_setting = hypertable.compression_settings.segmentby_setting.first
+          orderby_setting = hypertable.compression_settings.orderby_setting.first
+
+          sql_statements = ['timescaledb.compress']
+          sql_statements << "timescaledb.compress_segmentby = '#{segmentby_setting.attname}'" if segmentby_setting
+
+          if orderby_setting
+            orderby = Timescaledb::Rails::OrderbyCompression.new(orderby_setting.attname,
+                                                                 orderby_setting.orderby_asc).to_s
+
+            sql_statements << "timescaledb.compress_orderby = '#{orderby}'"
+          end
+
+          sql_statements.join(', ')
+        end
+
+        def timescale_enabled?
+          Timescaledb::Rails::Hypertable.table_exists?
+        end
+      end
+    end
+  end
+end

--- a/lib/timescaledb/rails/railtie.rb
+++ b/lib/timescaledb/rails/railtie.rb
@@ -3,6 +3,7 @@
 require 'rails'
 
 require_relative 'extensions/active_record/database_tasks'
+require_relative 'extensions/active_record/postgresql_database_tasks'
 require_relative 'extensions/active_record/schema_dumper'
 require_relative 'extensions/active_record/schema_statements'
 
@@ -18,8 +19,12 @@ module Timescaledb
 
       initializer 'timescaledb-rails.add_timescale_support_to_active_record' do
         ActiveSupport.on_load(:active_record) do
-          ::ActiveRecord::Tasks::PostgreSQLDatabaseTasks.prepend(
+          ::ActiveRecord::Tasks::DatabaseTasks.extend(
             Timescaledb::Rails::ActiveRecord::DatabaseTasks
+          )
+
+          ::ActiveRecord::Tasks::PostgreSQLDatabaseTasks.prepend(
+            Timescaledb::Rails::ActiveRecord::PostgreSQLDatabaseTasks
           )
 
           ::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend(


### PR DESCRIPTION
`_compressed_hypertable_*` tables were causing issues when enabling
 compression on hypertables.