### PR TITLE
fix: revert remove_hypertable_retention_policy

### DIFF
--- a/lib/timescaledb/rails/extensions/active_record/schema_statements.rb
+++ b/lib/timescaledb/rails/extensions/active_record/schema_statements.rb
@@ -76,7 +76,7 @@ module Timescaledb
         #
         #   remove_hypertable_retention_policy('events')
         #
-        def remove_hypertable_retention_policy(table_name)
+        def remove_hypertable_retention_policy(table_name, _drop_after = nil)
           execute "SELECT remove_retention_policy('#{table_name}')"
         end
 


### PR DESCRIPTION
Add missing drop_after param to remove_hypertable_retention_policy.